### PR TITLE
Improve previous implementation of disabling score multiplier

### DIFF
--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -117,16 +117,14 @@ namespace osu.Game.Online.Spectator
 
             Ruleset ruleset = rulesetInfo.CreateInstance();
 
+            scoreInfo = new ScoreInfo { Ruleset = rulesetInfo };
+
+            if (multiplayerClient?.Room?.Settings.NoScoreMultiplier == true)
+                scoreInfo.ScoreMultiplierCalculator = _ => 1;
+
             spectatorState = userState;
             scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = userState.Mods.Select(m => m.ToMod(ruleset)).ToArray();
-            if (multiplayerClient.Room?.Settings.NoScoreMultiplier == true)
-                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
-            scoreInfo = new ScoreInfo
-            {
-                Ruleset = rulesetInfo,
-                NoScoreMultiplier = multiplayerClient.Room?.Settings.NoScoreMultiplier == true
-            };
         }
 
         private void onNewFrames(int incomingUserId, FrameDataBundle bundle)

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -119,12 +119,15 @@ namespace osu.Game.Online.Spectator
 
             scoreInfo = new ScoreInfo { Ruleset = rulesetInfo };
 
-            if (multiplayerClient?.Room?.Settings.NoScoreMultiplier == true)
-                scoreInfo.ScoreMultiplierCalculator = _ => 1;
-
             spectatorState = userState;
             scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = userState.Mods.Select(m => m.ToMod(ruleset)).ToArray();
+
+            if (multiplayerClient?.Room?.Settings.NoScoreMultiplier == true)
+            {
+                scoreInfo.ScoreMultiplierCalculator = _ => 1;
+                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
+            }
         }
 
         private void onNewFrames(int incomingUserId, FrameDataBundle bundle)

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Online.Spectator
             scoreInfo = new ScoreInfo
             {
                 Ruleset = rulesetInfo,
-                IsScoreMultiplierDisabled = multiplayerClient.Room?.Settings.NoScoreMultiplier == true
+                NoScoreMultiplier = multiplayerClient.Room?.Settings.NoScoreMultiplier == true
             };
         }
 

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Online.Spectator
             scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = userState.Mods.Select(m => m.ToMod(ruleset)).ToArray();
             if (multiplayerClient.Room?.Settings.NoScoreMultiplier == true)
-                scoreProcessor.ScoreMultiplier = 1;
+                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
             scoreInfo = new ScoreInfo
             {
                 Ruleset = rulesetInfo,

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -154,9 +154,9 @@ namespace osu.Game.Rulesets.Scoring
 
         private double scoreMultiplier = 1;
 
-        private Func<IReadOnlyList<Mod>, double> scoreMultiplierCalculator;
+        private Func<ScoreInfo, double> scoreMultiplierCalculator;
 
-        public Func<IReadOnlyList<Mod>, double> ScoreMultiplierCalculator
+        public Func<ScoreInfo, double> ScoreMultiplierCalculator
         {
             get => scoreMultiplierCalculator;
             set
@@ -184,15 +184,7 @@ namespace osu.Game.Rulesets.Scoring
                     Rank.Value = mod.AdjustRank(Rank.Value, accuracy.NewValue);
             };
 
-            scoreMultiplierCalculator = mods =>
-            {
-                double scoreMultiplier = 1;
-
-                foreach (var m in mods)
-                    scoreMultiplier *= m.ScoreMultiplier;
-                
-                return scoreMultiplier;
-            };
+            scoreMultiplierCalculator = ScoreInfo.DefaultScoreMultiplierCalculator;
 
             Mode.ValueChanged += _ => updateScore();
             Mods.ValueChanged += _ => updateScoreFull();
@@ -300,7 +292,7 @@ namespace osu.Game.Rulesets.Scoring
 
         private void updateScoreFull()
         {
-            scoreMultiplier = ScoreMultiplierCalculator(Mods.Value);
+            scoreMultiplier = ScoreMultiplierCalculator(new ScoreInfo() { Mods = Mods.Value.ToArray() });
             updateScore();
         }
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Scoring
         public bool IsLegacyScore => Mods.OfType<ModClassic>().Any();
 
         [Ignored]
-        public bool IsScoreMultiplierDisabled { get; set; }
+        public bool NoScoreMultiplier { get; set; }
 
         private Dictionary<HitResult, int>? statistics;
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -185,7 +185,17 @@ namespace osu.Game.Scoring
         public bool IsLegacyScore => Mods.OfType<ModClassic>().Any();
 
         [Ignored]
-        public bool NoScoreMultiplier { get; set; }
+        public Func<ScoreInfo, double> ScoreMultiplierCalculator { get; set; } = DefaultScoreMultiplierCalculator;
+
+        public static readonly Func<ScoreInfo, double> DefaultScoreMultiplierCalculator = s =>
+        {
+            double scoreMultiplier = 1;
+            foreach (var mod in s.Mods)
+            {
+                scoreMultiplier *= mod.ScoreMultiplier;
+            }
+            return scoreMultiplier;
+        };
 
         private Dictionary<HitResult, int>? statistics;
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -113,9 +113,8 @@ namespace osu.Game.Scoring
 
             var ruleset = score.Ruleset.CreateInstance();
             var scoreProcessor = ruleset.CreateScoreProcessor();
+            scoreProcessor.ScoreMultiplierCalculator = score.ScoreMultiplierCalculator;
             scoreProcessor.Mods.Value = score.Mods;
-            if (score.NoScoreMultiplier)
-                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
 
             return scoreProcessor.ComputeScore(mode, score);
         }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Scoring
             var scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = score.Mods;
             if (score.NoScoreMultiplier)
-                scoreProcessor.ScoreMultiplier = 1;
+                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
 
             return scoreProcessor.ComputeScore(mode, score);
         }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Scoring
             var ruleset = score.Ruleset.CreateInstance();
             var scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = score.Mods;
-            if (score.IsScoreMultiplierDisabled)
+            if (score.NoScoreMultiplier)
                 scoreProcessor.ScoreMultiplier = 1;
 
             return scoreProcessor.ComputeScore(mode, score);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 AllowRestart = false,
                 AllowSkipping = room.AutoSkip.Value,
                 AutomaticallySkipIntro = room.AutoSkip.Value,
-                NoScoreMultiplier = room.NoScoreMultiplier.Value,
+                ScoreMultiplierCalculator = (room.NoScoreMultiplier.Value ? _ => 1 : ScoreInfo.DefaultScoreMultiplierCalculator),
                 AlwaysShowLeaderboard = true,
             })
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 AllowRestart = false,
                 AllowSkipping = room.AutoSkip.Value,
                 AutomaticallySkipIntro = room.AutoSkip.Value,
-                DisableScoreMultiplier = room.NoScoreMultiplier.Value,
+                NoScoreMultiplier = room.NoScoreMultiplier.Value,
                 AlwaysShowLeaderboard = true,
             })
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             : base(score, new PlayerConfiguration
             {
                 AllowUserInteraction = false,
-                NoScoreMultiplier = score.ScoreInfo.NoScoreMultiplier,
+                ScoreMultiplierCalculator = score.ScoreInfo.ScoreMultiplierCalculator,
             })
         {
             this.spectatorPlayerClock = spectatorPlayerClock;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             : base(score, new PlayerConfiguration
             {
                 AllowUserInteraction = false,
-                DisableScoreMultiplier = score.ScoreInfo.IsScoreMultiplierDisabled,
+                NoScoreMultiplier = score.ScoreInfo.NoScoreMultiplier,
             })
         {
             this.spectatorPlayerClock = spectatorPlayerClock;

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
                 foreach (var scoreInfo in scoreInfos)
                 {
-                    scoreInfo.IsScoreMultiplierDisabled = true;
+                    scoreInfo.NoScoreMultiplier = true;
                     scoreInfo.TotalScore = scoreProcessor.ComputeScore(Rulesets.Scoring.ScoringMode.Standardised, scoreInfo);
                 }
             }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                 // recalculate score without score multiplier
                 var ruleset = Ruleset.Value.CreateInstance();
                 var scoreProcessor = ruleset.CreateScoreProcessor();
-                scoreProcessor.ScoreMultiplier = 1;
+                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
 
                 foreach (var scoreInfo in scoreInfos)
                 {

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
@@ -190,15 +190,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             if (multiplayerClient?.Room?.Settings.NoScoreMultiplier == true)
             {
-                // recalculate score without score multiplier
-                var ruleset = Ruleset.Value.CreateInstance();
-                var scoreProcessor = ruleset.CreateScoreProcessor();
-                scoreProcessor.ScoreMultiplierCalculator = _ => 1;
-
                 foreach (var scoreInfo in scoreInfos)
                 {
-                    scoreInfo.NoScoreMultiplier = true;
-                    scoreInfo.TotalScore = scoreProcessor.ComputeScore(Rulesets.Scoring.ScoringMode.Standardised, scoreInfo);
+                    scoreInfo.ScoreMultiplierCalculator = _ => 1;
                 }
             }
 

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Play
             Mods = mods ?? Array.Empty<Mod>();
             ScoreProcessor = scoreProcessor ?? ruleset.CreateScoreProcessor();
             if (Score.ScoreInfo.NoScoreMultiplier)
-                ScoreProcessor.ScoreMultiplier = 1;
+                ScoreProcessor.ScoreMultiplierCalculator = _ => 1;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.Play
             };
             Mods = mods ?? Array.Empty<Mod>();
             ScoreProcessor = scoreProcessor ?? ruleset.CreateScoreProcessor();
-            if (Score.ScoreInfo.IsScoreMultiplierDisabled)
+            if (Score.ScoreInfo.NoScoreMultiplier)
                 ScoreProcessor.ScoreMultiplier = 1;
         }
 

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -76,8 +76,7 @@ namespace osu.Game.Screens.Play
             };
             Mods = mods ?? Array.Empty<Mod>();
             ScoreProcessor = scoreProcessor ?? ruleset.CreateScoreProcessor();
-            if (Score.ScoreInfo.NoScoreMultiplier)
-                ScoreProcessor.ScoreMultiplierCalculator = _ => 1;
+            ScoreProcessor.ScoreMultiplierCalculator = Score.ScoreInfo.ScoreMultiplierCalculator;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -230,7 +230,7 @@ namespace osu.Game.Screens.Play
             ScoreProcessor.Mods.Value = gameplayMods;
             ScoreProcessor.ApplyBeatmap(playableBeatmap);
             if (Configuration.NoScoreMultiplier)
-                ScoreProcessor.ScoreMultiplier = 1;
+                ScoreProcessor.ScoreMultiplierCalculator = _ => 1;
 
             dependencies.CacheAs(ScoreProcessor);
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Screens.Play
             ScoreProcessor = ruleset.CreateScoreProcessor();
             ScoreProcessor.Mods.Value = gameplayMods;
             ScoreProcessor.ApplyBeatmap(playableBeatmap);
-            if (Configuration.DisableScoreMultiplier)
+            if (Configuration.NoScoreMultiplier)
                 ScoreProcessor.ScoreMultiplier = 1;
 
             dependencies.CacheAs(ScoreProcessor);
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Play
             Score.ScoreInfo.BeatmapHash = Beatmap.Value.BeatmapInfo.Hash;
             Score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
             Score.ScoreInfo.Mods = gameplayMods;
-            Score.ScoreInfo.IsScoreMultiplierDisabled = Configuration.DisableScoreMultiplier;
+            Score.ScoreInfo.NoScoreMultiplier = Configuration.NoScoreMultiplier;
 
             dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor));
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -227,10 +227,9 @@ namespace osu.Game.Screens.Play
             dependencies.CacheAs(DrawableRuleset);
 
             ScoreProcessor = ruleset.CreateScoreProcessor();
+            ScoreProcessor.ScoreMultiplierCalculator = Configuration.ScoreMultiplierCalculator;
             ScoreProcessor.Mods.Value = gameplayMods;
             ScoreProcessor.ApplyBeatmap(playableBeatmap);
-            if (Configuration.NoScoreMultiplier)
-                ScoreProcessor.ScoreMultiplierCalculator = _ => 1;
 
             dependencies.CacheAs(ScoreProcessor);
 
@@ -253,7 +252,7 @@ namespace osu.Game.Screens.Play
             Score.ScoreInfo.BeatmapHash = Beatmap.Value.BeatmapInfo.Hash;
             Score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
             Score.ScoreInfo.Mods = gameplayMods;
-            Score.ScoreInfo.NoScoreMultiplier = Configuration.NoScoreMultiplier;
+            Score.ScoreInfo.ScoreMultiplierCalculator = Configuration.ScoreMultiplierCalculator;
 
             dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor));
 

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -3,6 +3,9 @@
 
 #nullable disable
 
+using System;
+using osu.Game.Scoring;
+
 namespace osu.Game.Screens.Play
 {
     public class PlayerConfiguration
@@ -43,8 +46,8 @@ namespace osu.Game.Screens.Play
         public bool AlwaysShowLeaderboard { get; set; }
 
         /// <summary>
-        /// Whether all displayed scores during gameplay should be shown without score multiplier applied.
+        /// Determines how score multiplier for all displayed scores should be computed.
         /// </summary>
-        public bool NoScoreMultiplier { get; set; }
+        public Func<ScoreInfo, double> ScoreMultiplierCalculator { get; set; } = ScoreInfo.DefaultScoreMultiplierCalculator;
     }
 }

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -45,6 +45,6 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Whether all displayed scores during gameplay should be shown without score multiplier applied.
         /// </summary>
-        public bool DisableScoreMultiplier { get; set; }
+        public bool NoScoreMultiplier { get; set; }
     }
 }

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -172,11 +172,15 @@ namespace osu.Game.Screens.Spectate
                     BeatmapInfo = resolvedBeatmap,
                     User = user,
                     Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
-                    Ruleset = resolvedRuleset.RulesetInfo,
-                    NoScoreMultiplier = multiplayerClient?.Room?.Settings.NoScoreMultiplier == true
+                    Ruleset = resolvedRuleset.RulesetInfo
                 },
                 Replay = new Replay { HasReceivedAllFrames = false },
             };
+
+            if (multiplayerClient?.Room?.Settings.NoScoreMultiplier == true)
+            {
+                score.ScoreInfo.ScoreMultiplierCalculator = _ => 1;
+            }
 
             var gameplayState = new SpectatorGameplayState(score, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));
 

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.Spectate
                     User = user,
                     Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
                     Ruleset = resolvedRuleset.RulesetInfo,
-                    IsScoreMultiplierDisabled = multiplayerClient?.Room?.Settings.NoScoreMultiplier == true
+                    NoScoreMultiplier = multiplayerClient?.Room?.Settings.NoScoreMultiplier == true
                 },
                 Replay = new Replay { HasReceivedAllFrames = false },
             };


### PR DESCRIPTION
This adds `ScoreProcessor.ScoreMultiplierCalculator` and `ScoreInfo.ScoreMultiplierCalculator` which handle everything. Because `ScoreInfo` now stores info on how to compute multiplier, there is less checks required throughout the codebase.